### PR TITLE
Make it pass desktop-file-validate

### DIFF
--- a/contrib/org.sigrok.PulseView.desktop
+++ b/contrib/org.sigrok.PulseView.desktop
@@ -7,4 +7,4 @@ Comment=Control your logic analyzer, oscilloscope, or MSO
 Exec=pulseview
 Icon=sigrok-logo-notext
 Type=Application
-MimeType=application/vnd.sigrok.session
+MimeType=application/vnd.sigrok.session;


### PR DESCRIPTION
Make it pass `desktop-file-validate` on Ubuntu trusty.

References:
- https://travis-ci.org/AppImage/appimage.github.io/builds/306921880#L695
- https://github.com/AppImage/appimage.github.io/pull/192